### PR TITLE
docs: fix abbreviation README typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ A natural consequence of generating all the abbreviations for a set of one word 
 
 As shown in the example above, limiting the input set to one word results in the output of a regex alternation string. The rest of this description applies to sets of two or more words.
 
-Abbrevians for multiple-word sets
+Abbreviations for multiple-word sets
 ---------------------------------
 
 The input multiple-word set can be in one of three forms: (1) a list (recommended), (2) a string containing the words separated by spaces, or (3) as a hash (or set) with the words being keys of the hash (set members). Duplicate words will be automatically and quietly eliminated.
@@ -75,7 +75,7 @@ There are two shorter alias names for `sub abbreviations` one can use that are a
  abbrev
 ```
 
-In the sprit of the module, one can `use Abbreviations :ALL;` and have these additional shorter alias names available:
+In the spirit of the module, one can `use Abbreviations :ALL;` and have these additional shorter alias names available:
 
 ```raku
  abbre
@@ -202,4 +202,3 @@ COPYRIGHT and LICENSE
 Copyright © 2020-2023 Tom Browder
 
 This library is free software; you may redistribute or modify it under the Artistic License 2.0.
-

--- a/docs/README.rakudoc
+++ b/docs/README.rakudoc
@@ -67,7 +67,7 @@ As shown in the example above, limiting the input set to one word
 results in the output of a regex alternation string. The rest
 of this description applies to sets of two or more words.
 
-=head2 Abbrevians for multiple-word sets
+=head2 Abbreviations for multiple-word sets
 
 The input multiple-word set can be in one of three forms: (1) a list
 (recommended), (2) a string containing the words separated by spaces,
@@ -99,7 +99,7 @@ use that are always exported:
  abbrev
 =end code
 
-In the sprit of the module, one can C<use Abbreviations :ALL;> and
+In the spirit of the module, one can C<use Abbreviations :ALL;> and
 have these additional shorter alias names available:
 
 =begin code :lang<raku>


### PR DESCRIPTION
Fixes #12

Corrects the README heading typo and the nearby "sprit" typo in the module description.